### PR TITLE
fix(ci): switch token to `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Release
 
 on:
   push:
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
@@ -21,4 +23,4 @@ jobs:
       - name: Run semantic-release
         run: make semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.EINRIDEBOT_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
since the Einride bot one isn't available in public repos. Also add write access to the token in the release job to allow Dependabot to create releases.