### PR TITLE
fix(SetTimeStamp): dont block on ctx done

### DIFF
--- a/externalclock/clock.go
+++ b/externalclock/clock.go
@@ -33,8 +33,14 @@ func New(logger logr.Logger, initialTime time.Time) *Clock {
 	return c
 }
 
-func (g *Clock) SetTimestamp(t time.Time) {
-	g.timestampChan <- t
+func (g *Clock) SetTimestamp(ctx context.Context, t time.Time) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case g.timestampChan <- t:
+		}
+	}
 }
 
 func (g *Clock) NumberOfTriggers() int {

--- a/externalclock/ticker_test.go
+++ b/externalclock/ticker_test.go
@@ -1,6 +1,7 @@
 package externalclock_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -31,7 +32,7 @@ func TestExternalClock_TickerReset(t *testing.T) {
 	// we let the clock go up to 5, giving 1 tick at 3.
 	for i := 0; i < count/2; i++ {
 		externalTime = externalTime.Add(delta)
-		externalClock.SetTimestamp(externalTime)
+		externalClock.SetTimestamp(context.Background(), externalTime)
 		// add sleep to let the channels clear between the calls.
 		time.Sleep(time.Millisecond)
 	}
@@ -40,7 +41,7 @@ func TestExternalClock_TickerReset(t *testing.T) {
 	loopTicker.Reset(tickerDelta)
 	for i := count / 2; i < count; i++ {
 		externalTime = externalTime.Add(delta)
-		externalClock.SetTimestamp(externalTime)
+		externalClock.SetTimestamp(context.Background(), externalTime)
 	}
 	cancel <- struct{}{}
 	assert.DeepEqual(t, receivedTime, []time.Time{time.UnixMilli(3), time.UnixMilli(8)})


### PR DESCRIPTION
Would deadlock if this function was called when the Run() function had recieved a ctx.Done()