### PR TITLE
fix(externalclock): mutex around access to map

### DIFF
--- a/externalclock/clock.go
+++ b/externalclock/clock.go
@@ -38,6 +38,8 @@ func (g *Clock) SetTimestamp(t time.Time) {
 }
 
 func (g *Clock) NumberOfTriggers() int {
+	g.tickerMutex.RLock()
+	defer g.tickerMutex.RUnlock()
 	return len(g.tickers)
 }
 


### PR DESCRIPTION
Avoids data race errors when used in unit tests.