### PR TITLE
fix(externalclock): fix setTimestamp (issue #103)

### DIFF
--- a/externalclock/clock_test.go
+++ b/externalclock/clock_test.go
@@ -46,7 +46,6 @@ func TestExternalClock_Now(t *testing.T) {
 	for i := 0; i < 10; i++ { // repeat a few times to try to trigger racing
 		for _, ts := range timeList {
 			// Given
-			externalClock.SetTimestamp(time.Unix(0, 1))
 			externalClock.SetTimestamp(ts)
 			// Expect
 			cnow := externalClock.Now()

--- a/externalclock/clock_test.go
+++ b/externalclock/clock_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	testr "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"go.einride.tech/clock/externalclock"
 	"golang.org/x/sync/errgroup"
 	"gotest.tools/v3/assert"
@@ -306,7 +306,7 @@ func (t *testLooper) Run(ctx context.Context) error {
 
 func newTestFixture(t *testing.T) *externalclock.Clock {
 	t.Helper()
-	c := externalclock.New(testr.NewTestLogger(t), time.Unix(0, 0))
+	c := externalclock.New(testr.New(t), time.Unix(0, 0))
 	var g errgroup.Group
 	g.Go(func() error {
 		if err := c.Run(context.Background()); err != nil {


### PR DESCRIPTION
This PR contains a tentative fix for issue #103.

The PR starts by fixing the test, and replacing a call to a deprecated lib function.

The fix proposed in the issue is not adopted as it can result in notifying tickers twice (so one extra unnecessary time).
Instead a notification mechanism is added so that `SetTimestamp` is only freed when time had indeed been updated.