### PR TITLE
fix(externalclock): fix deadlock when sending time on unstarted Clock

### DIFF
--- a/externalclock/clock_test.go
+++ b/externalclock/clock_test.go
@@ -230,6 +230,24 @@ func TestExternalClock_NewTicker_Tick_Periodically(t *testing.T) {
 	}
 }
 
+func TestExternalClock_SendBeforeRun(t *testing.T) {
+	// test verifies that sending time on an unstarted clock does not deadlock
+	c := externalclock.New(testr.New(t), time.Unix(0, 0))
+	c.SetTimestamp(time.Unix(1, 0))
+}
+
+func TestExternalClock_SendAfterRun(t *testing.T) {
+	// test verifies that sending time on a cancelled clock does not deadlock
+	c := externalclock.New(testr.New(t), time.Unix(0, 0))
+	// start clock with a deadline
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	t.Cleanup(cancel)
+	assert.NilError(t, c.Run(ctx))
+
+	// sending time
+	c.SetTimestamp(time.Unix(1, 0))
+}
+
 func TestExternalClock_TestLooper(t *testing.T) {
 	externalClock := newTestFixture(t)
 	const target = 1000

--- a/externalclock/ticker.go
+++ b/externalclock/ticker.go
@@ -61,7 +61,10 @@ func (g *Clock) NewTicker(d time.Duration) clock.Ticker {
 }
 
 func (g *Clock) newTickerInternal(caller string, endFunc func(), d time.Duration, periodic bool) clock.Ticker {
-	c := make(chan time.Time)
+	// Give the channel a 1-element time buffer.
+	// If the client falls behind while reading, we drop ticks
+	// on the floor until the client catches up.
+	c := make(chan time.Time, 1)
 	uuid := makeUUID()
 	intervalTicker := &ticker{
 		caller:   caller,

--- a/externalclock/ticker_test.go
+++ b/externalclock/ticker_test.go
@@ -41,6 +41,7 @@ func TestExternalClock_TickerReset(t *testing.T) {
 	for i := count / 2; i < count; i++ {
 		externalTime = externalTime.Add(delta)
 		externalClock.SetTimestamp(externalTime)
+		time.Sleep(time.Millisecond)
 	}
 	cancel <- struct{}{}
 	assert.DeepEqual(t, receivedTime, []time.Time{time.UnixMilli(3), time.UnixMilli(8)})


### PR DESCRIPTION
Calling `SetTimestamp` on a clock will block until the `Run` goroutine
has read on channel and acked on another channel. If the Clock isn't
started (or has been closed) calling `SetTimestamp` blocks
forever (unless clock is started later).

This commit fixes this issue by setting time and signaling tickers in
the calling goroutine (as opposed to `Run` goroutine).

This change also means that `Run` doesn't do anything, so it is marked
as deprecated.
