### PR TITLE
fix: remove data race when resetting ticker

### DIFF
--- a/externalclock/ticker.go
+++ b/externalclock/ticker.go
@@ -30,12 +30,18 @@ func (t *ticker) Stop() {
 
 func (t *ticker) Reset(duration time.Duration) {
 	now := t.getTimeFunc()
+	t.mutex.Lock()
 	t.duration = duration
-	t.SetLastTimestamp(now)
+	t.lastTimeStamp = now
+	t.mutex.Unlock()
 }
 
 func (t *ticker) IsDurationReached(currentTime time.Time) bool {
-	return t.duration <= currentTime.Sub(t.GetLastTimestamp())
+	t.mutex.Lock()
+	dur := t.duration
+	ts := t.lastTimeStamp
+	t.mutex.Unlock()
+	return dur <= currentTime.Sub(ts)
 }
 
 func (t *ticker) GetLastTimestamp() time.Time {


### PR DESCRIPTION
Currently there is a data race in the Ticker that is triggered when
Ticker.Reset and Ticker.IsDurationReached are called concurrently.
IsDurationReached is called by the clock as part of Clock.SetTimestamp and
Ticker.Reset is called by user-code.

This commit fixes the data race by protecting `duration` field of Ticker
with the mutex. This also forces inlining of some calls in both methods
as the called methods will also attempt to lock the mutex.
