### PR TITLE
refactor!: use slog for logging

### DIFF
--- a/externalclock/clock.go
+++ b/externalclock/clock.go
@@ -5,26 +5,24 @@ import (
 	"crypto/rand"
 	"fmt"
 	"log"
+	"log/slog"
 	"runtime"
 	"sync"
 	"time"
 
-	"github.com/go-logr/logr"
 	"go.einride.tech/clock"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type Clock struct {
-	Logger      logr.Logger
 	timeMutex   sync.Mutex
 	currentTime time.Time
 	tickerMutex sync.RWMutex
 	tickers     map[string]*ticker
 }
 
-func New(logger logr.Logger, initialTime time.Time) *Clock {
+func New(initialTime time.Time) *Clock {
 	c := &Clock{
-		Logger:  logger,
 		tickers: map[string]*ticker{},
 	}
 	c.currentTime = initialTime
@@ -54,7 +52,7 @@ func (g *Clock) signalTickers(t time.Time) {
 		select {
 		case tickerInstance.timeChan <- t:
 		case <-time.After(20 * time.Millisecond):
-			g.Logger.V(1).Info("ticker dropped message", "caller", tickerInstance.caller)
+			slog.Debug("ticker dropped message", slog.String("caller", tickerInstance.caller))
 		}
 	}
 	g.tickerMutex.RUnlock()

--- a/externalclock/clock_test.go
+++ b/externalclock/clock_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr/testr"
 	"go.einride.tech/clock/externalclock"
 	"golang.org/x/sync/errgroup"
 	"gotest.tools/v3/assert"
@@ -232,13 +231,14 @@ func TestExternalClock_NewTicker_Tick_Periodically(t *testing.T) {
 
 func TestExternalClock_SendBeforeRun(t *testing.T) {
 	// test verifies that sending time on an unstarted clock does not deadlock
-	c := externalclock.New(testr.New(t), time.Unix(0, 0))
+	_ = t
+	c := externalclock.New(time.Unix(0, 0))
 	c.SetTimestamp(time.Unix(1, 0))
 }
 
 func TestExternalClock_SendAfterRun(t *testing.T) {
 	// test verifies that sending time on a cancelled clock does not deadlock
-	c := externalclock.New(testr.New(t), time.Unix(0, 0))
+	c := externalclock.New(time.Unix(0, 0))
 	// start clock with a deadline
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	t.Cleanup(cancel)
@@ -354,7 +354,7 @@ func (t *testLooper) Run(ctx context.Context) error {
 
 func newTestFixture(t *testing.T) *externalclock.Clock {
 	t.Helper()
-	c := externalclock.New(testr.New(t), time.Unix(0, 0))
+	c := externalclock.New(time.Unix(0, 0))
 	var g errgroup.Group
 	g.Go(func() error {
 		if err := c.Run(context.Background()); err != nil {

--- a/externalclock/ticker.go
+++ b/externalclock/ticker.go
@@ -2,6 +2,7 @@ package externalclock
 
 import (
 	"fmt"
+	"log/slog"
 	"runtime"
 	"sync"
 	"time"
@@ -62,7 +63,7 @@ func (g *Clock) NewTicker(d time.Duration) clock.Ticker {
 	if ok {
 		caller = fmt.Sprintf("called from %s#%d\n", file, no)
 	}
-	g.Logger.V(1).Info("added new ticker", "caller", caller)
+	slog.Debug("added new ticker", slog.String("caller", caller))
 	return g.newTickerInternal(caller, nil, d, true)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module go.einride.tech/clock
 go 1.17
 
 require (
-	github.com/go-logr/logr v1.4.1
 	golang.org/x/sync v0.7.0
 	google.golang.org/protobuf v1.34.1
 	gotest.tools/v3 v3.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
-github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=


### PR DESCRIPTION
Currently externalclock takes a logr and uses it for some debug
logging. Since log/slog now exists in std library we should use it.

This commit removes logr dependency with using slog directly.
This is a breaking change as the signature for externalclock.New
changes. Previous calls to `externalclock.New(logr, time)` can safely
drop the `logr` argument.
