### PR TITLE
chore: add dependabot cooldown settings to mitigate ongoing supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,9 +41,6 @@ updates:
 
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
   - package-ecosystem: gomod
     directory: .sage
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,10 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+      exclude:
+        - github.com/einride/*
+        - github.com/einride-autonomous/*
+        - github.com/einride-labs/*
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -41,6 +45,10 @@ updates:
 
     cooldown:
       default-days: 7
+      exclude:
+        - github.com/einride/*
+        - github.com/einride-autonomous/*
+        - github.com/einride-labs/*
   - package-ecosystem: gomod
     directory: .sage
     schedule:
@@ -53,3 +61,7 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+      exclude:
+        - github.com/einride/*
+        - github.com/einride-autonomous/*
+        - github.com/einride-labs/*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
           - "minor"
           - "patch"
 
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -34,6 +39,11 @@ updates:
       prefix: chore
       include: scope
 
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: gomod
     directory: .sage
     schedule:
@@ -41,3 +51,8 @@ updates:
       day: "monday"
       time: "05:08"
       timezone: "Europe/Stockholm"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
## Summary

Adds `cooldown` configuration to every package ecosystem in `.github/dependabot.yml` to reduce exposure to ongoing supply chain attacks by limiting how quickly compromised or malicious package versions can be automatically adopted.

```yaml
cooldown:
  default-days: 7
  semver-major-days: 30
  semver-minor-days: 7
  semver-patch-days: 3
  exclude:
    - github.com/einride/*
    - github.com/einride-autonomous/*
    - github.com/einride-labs/*
```

Security updates are automatically exempt from this cooldown.
